### PR TITLE
Fix NDK prebuilt detection add robust Go executable detection & vendor pre-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,46 @@ Please help with translations using [Weblate](https://toolate.othing.xyz/project
 - **Database**: Room
 - **Networking**: OkHttp, libv2ray
 
+# How to run
+A compact set of copy-paste commands to build the app on different OSes.
+
+- Build debug APK (macOS / Linux):
+
+```bash
+# from repository root
+./gradlew :app:assembleDebug
+```
+
+- Build debug APK (Windows CMD/PowerShell):
+
+```powershell
+# from repository root (PowerShell)
+.\\gradlew.bat :app:assembleDebug
+```
+
+- Vendor Go dependencies only:
+
+```bash
+./gradlew :app:vendorGoDependencies
+```
+
+- Clean build artifacts:
+
+```bash
+./gradlew clean
+```
+
+- If `go` is not on PATH, override the detected `go` binary:
+
+```bash
+# macOS / Linux
+export GO_EXECUTABLE=/opt/homebrew/bin/go
+./gradlew :app:vendorGoDependencies
+
+# Or pass as Gradle property
+./gradlew -PGO_EXECUTABLE=/opt/homebrew/bin/go :app:vendorGoDependencies
+```
+
 ## License
 
 This package is licensed under the [LICENSE](./LICENSE) for details.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -305,7 +305,16 @@ ext {
     v2rayRepo = 'https://github.com/2dust/AndroidLibXrayLite.git'
     v2rayCommit = '93a711245dec705be8dd6aa6a47f8aafa7898c40'
     buildDirV2ray = file("${project.rootDir}/build/v2ray")
-    goExecutable = file('/usr/local/go/bin/go').exists() ? '/usr/local/go/bin/go' : 'go'
+    // Resolve Go executable robustly: allow env/project override, check common install locations, fall back to PATH 'go'
+    goExecutable = ({
+        def envOverride = System.getenv('GO_EXECUTABLE')
+        if (envOverride && file(envOverride).exists()) return envOverride
+        if (project.hasProperty('GO_EXECUTABLE') && file(project.property('GO_EXECUTABLE')).exists()) return project.property('GO_EXECUTABLE')
+        def candidates = ['/opt/homebrew/bin/go', '/usr/local/go/bin/go', '/usr/local/bin/go', '/usr/bin/go']
+        def found = candidates.find { file(it).exists() }
+        if (found) return found
+        return 'go'
+    })()
     gitExecutable = file('/usr/bin/git').exists() ? '/usr/bin/git' : 'git'
 }
 
@@ -330,6 +339,20 @@ static def findNdkPath(Project project) {
 }
 
 def ndkPath = findNdkPath(project)
+
+// Detect the correct prebuilt toolchain folder inside the NDK (e.g. darwin-x86_64, linux-x86_64, windows-x86_64)
+def prebuiltToolchainsDir = file("${ndkPath}/toolchains/llvm/prebuilt")
+if (!prebuiltToolchainsDir.exists()) {
+    throw new GradleException("NDK toolchains prebuilt directory not found at: ${prebuiltToolchainsDir}. Check your NDK installation and ndk.dir/ANDROID_NDK_HOME/ANDROID_NDK_ROOT settings.")
+}
+
+def prebuiltChildren = prebuiltToolchainsDir.listFiles()?.findAll { it.isDirectory() } ?: []
+if (prebuiltChildren.size() == 0) {
+    throw new GradleException("No prebuilt toolchain directory found under ${prebuiltToolchainsDir}.")
+}
+
+def ndkPrebuiltFolder = (prebuiltChildren.find { it.name.contains('darwin') } ?: prebuiltChildren[0]).name
+println "Using NDK prebuilt folder: ${ndkPrebuiltFolder}"
 
 def archConfigs = [
         'arm64-v8a'  : [goArch: 'arm64', target: 'aarch64-linux-android'],
@@ -382,6 +405,23 @@ tasks.register('vendorGoDependencies') {
 
     inputs.file("${builderDir}/builder.go")
     outputs.dir(vendorDir)
+
+    // Pre-check: ensure the `go` executable is available and runnable before attempting to vendor.
+    doFirst {
+        println "--- (CHECK) Verifying Go executable ---"
+        def overrideEnv = System.getenv('GO_EXECUTABLE')
+        def overrideProp = project.hasProperty('GO_EXECUTABLE') ? project.property('GO_EXECUTABLE') : null
+        def goExecCandidate = overrideEnv ?: overrideProp ?: goExecutable
+        try {
+            exec {
+                workingDir builderDir
+                commandLine goExecCandidate, 'version'
+                // don't capture output; failure will throw an exception
+            }
+        } catch (Exception e) {
+            throw new GradleException("Go executable not found or failed to run. Tried: ${goExecCandidate}.\nInstall Go (e.g. on macOS: 'brew install go') or set environment variable GO_EXECUTABLE=/path/to/go or pass -PGO_EXECUTABLE=/path/to/go. Original error: ${e.message}")
+        }
+    }
 
     doLast {
         println "--- Initializing main Go module and vendoring dependencies ---"
@@ -455,7 +495,7 @@ archConfigs.each { abi, config ->
         workingDir builderDir
 
         def apiLevel = 21
-        def toolchainPath = "${ndkPath}/toolchains/llvm/prebuilt/linux-x86_64"
+        def toolchainPath = "${ndkPath}/toolchains/llvm/prebuilt/${ndkPrebuiltFolder}"
         def compiler = "${toolchainPath}/bin/${target}${apiLevel}-clang"
         def sysroot = "${toolchainPath}/sysroot"
 


### PR DESCRIPTION
This PR fixes fragile Gradle configuration/runtime failures and improves documentation:

1. Ensure `ndkPrebuiltFolder` is discovered at configuration time to let dynamically registered Go build tasks compute toolchain paths reliably.
2. Add robust Go detection with env/project override support and a Go version pre-check in `:app:vendorGoDependencies`. This provides a clear fail-fast error if Go is missing or misconfigured.
3. Add a concise **“How to run”** section to `README.md` with copy-paste commands for **macOS**, **Linux**, and **Windows**.

---

🙏 **Thank you for creating the awesome project:**  
https://github.com/alexch33/super-video-downloader
