### PR TITLE
refactor favicon handling to use Glide and ByteArray, and improve You…

### DIFF
--- a/app/src/main/java/com/myAllVideoBrowser/DLApplication.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/DLApplication.kt
@@ -52,6 +52,8 @@ open class DLApplication : DaggerApplication(), Configuration.Provider {
     @Inject
     lateinit var adBlockEngine: AdBlockEngine
 
+    private var isYoutubeDLInitialized = false
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -104,7 +106,9 @@ open class DLApplication : DaggerApplication(), Configuration.Provider {
             }
 
             initializeYoutubeDl()
-            updateYoutubeDL()
+            if (isYoutubeDLInitialized) {
+                updateYoutubeDL()
+            }
 
             startProxyWorker()
 
@@ -132,20 +136,30 @@ open class DLApplication : DaggerApplication(), Configuration.Provider {
 
     private fun initializeYoutubeDl() {
         try {
-            YoutubeDL.getInstance().init(applicationContext)
-            FFmpeg.getInstance().init(applicationContext)
+            YoutubeDL.getInstance().init(this)
+            FFmpeg.getInstance().init(this)
+            isYoutubeDLInitialized = true
+            AppLogger.i("YoutubeDL and FFmpeg initialized successfully")
         } catch (e: YoutubeDLException) {
-            AppLogger.e("failed to initialize youtubedl-android $e")
+            isYoutubeDLInitialized = false
+            AppLogger.e("failed to initialize youtubedl-android: ${e.message}")
+        } catch (e: Exception) {
+            isYoutubeDLInitialized = false
+            AppLogger.e("unexpected error during youtubedl-android init: ${e.message}")
         }
     }
 
     private fun updateYoutubeDL() {
+        if (!isYoutubeDLInitialized) {
+            AppLogger.w("Skipping updateYoutubeDL: instance not initialized")
+            return
+        }
         try {
             val status = YoutubeDL.getInstance()
-                .updateYoutubeDL(applicationContext, YoutubeDL.UpdateChannel._MASTER)
+                .updateYoutubeDL(this, YoutubeDL.UpdateChannel._MASTER)
             AppLogger.d("UPDATE_STATUS MASTER: $status")
         } catch (e: Throwable) {
-            e.printStackTrace()
+            AppLogger.e("Failed to update YoutubeDL: ${e.message}")
         }
     }
 

--- a/app/src/main/java/com/myAllVideoBrowser/data/local/room/entity/HistoryItem.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/data/local/room/entity/HistoryItem.kt
@@ -1,7 +1,5 @@
 package com.myAllVideoBrowser.data.local.room.entity
 
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -19,10 +17,6 @@ data class HistoryItem(
     @ColumnInfo(typeAffinity = ColumnInfo.BLOB)
     var favicon: ByteArray? = null
 ) {
-
-    fun faviconBitmap(): Bitmap? {
-        return BitmapFactory.decodeByteArray(favicon, 0, favicon?.size ?: 0)
-    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/app/src/main/java/com/myAllVideoBrowser/data/local/room/entity/PageInfo.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/data/local/room/entity/PageInfo.kt
@@ -1,7 +1,5 @@
 package com.myAllVideoBrowser.data.local.room.entity
 
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -49,13 +47,6 @@ data class PageInfo(
             .replace("www.", "")
             .replace(".com", "")
             .replaceFirstChar { it.uppercase() }
-    }
-
-    fun faviconBitmap(): Bitmap? {
-        if (favicon == null) {
-            return null
-        }
-        return BitmapFactory.decodeByteArray(favicon, 0, favicon?.size ?: 0)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/com/myAllVideoBrowser/data/repository/TopPagesRepository.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/data/repository/TopPagesRepository.kt
@@ -50,8 +50,8 @@ class TopPagesRepositoryImpl @Inject constructor(
     override suspend fun updateLocalStorageFavicons(): Flow<PageInfo> = callbackFlow {
         val pages = localDataSource.getTopPages()
         for (page in pages) {
-            if (page.faviconBitmap() == null) {
-                val bitmap = try {
+            if (page.favicon == null) {
+                val bitmapBytes = try {
                     FaviconUtils.getEncodedFaviconFromUrl(
                         okHttpClient.getProxyOkHttpClient(), page.link
                     )
@@ -59,11 +59,6 @@ class TopPagesRepositoryImpl @Inject constructor(
                     null
                 }
 
-                val bitmapBytes = try {
-                    FaviconUtils.bitmapToBytes(bitmap)
-                } catch (e: Throwable) {
-                    null
-                }
                 page.favicon = bitmapBytes
                 localDataSource.saveTopPage(page)
                 delay(10)

--- a/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/BookmarksAdapter.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/BookmarksAdapter.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.myAllVideoBrowser.R
 import com.myAllVideoBrowser.data.local.room.entity.PageInfo
 import com.myAllVideoBrowser.databinding.ItemBookmarkBinding
@@ -39,13 +40,16 @@ class BookmarksAdapter(
                 this.bookmarkItem = bookmarkItem
                 this.bookmarksListener = bookmarksListener
 
-                if (bookmarkItem.faviconBitmap() == null) {
-                    val bm = AppCompatResources.getDrawable(
-                        ContextUtils.getApplicationContext(), R.drawable.ic_browser
-                    )
+                val placeholder = AppCompatResources.getDrawable(
+                    ContextUtils.getApplicationContext(), R.drawable.ic_browser
+                )
 
-                    this.favicon.setImageDrawable(bm)
-                }
+                Glide.with(favicon.context)
+                    .load(bookmarkItem.favicon)
+                    .placeholder(placeholder)
+                    .error(placeholder)
+                    .circleCrop()
+                    .into(favicon)
 
                 executePendingBindings()
             }

--- a/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/HistoryAdapter.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/HistoryAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.github.marlonlom.utilities.timeago.TimeAgo
 import com.github.marlonlom.utilities.timeago.TimeAgoMessages
 import com.myAllVideoBrowser.R
@@ -40,15 +41,17 @@ class HistoryAdapter(
                 this.historyId = historyItem.id
                 this.tvTime.text = convertTimeToTimeAgo(historyItem.datetime)
 
-                if (historyItem.faviconBitmap() == null) {
-                    val bm =
-                        AppCompatResources.getDrawable(
-                            ContextUtils.getApplicationContext(),
-                            R.drawable.ic_browser
-                        )
+                val placeholder = AppCompatResources.getDrawable(
+                    ContextUtils.getApplicationContext(),
+                    R.drawable.ic_browser
+                )
 
-                    this.favicon.setImageDrawable(bm)
-                }
+                Glide.with(favicon.context)
+                    .load(historyItem.favicon)
+                    .placeholder(placeholder)
+                    .error(placeholder)
+                    .circleCrop()
+                    .into(favicon)
 
                 executePendingBindings()
             }

--- a/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/HistorySearchAdapter.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/HistorySearchAdapter.kt
@@ -2,7 +2,6 @@ package com.myAllVideoBrowser.ui.component.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.github.marlonlom.utilities.timeago.TimeAgo
@@ -10,7 +9,6 @@ import com.github.marlonlom.utilities.timeago.TimeAgoMessages
 import com.myAllVideoBrowser.R
 import com.myAllVideoBrowser.data.local.room.entity.HistoryItem
 import com.myAllVideoBrowser.databinding.ItemHistorySearchBinding
-import com.myAllVideoBrowser.util.ContextUtils
 import java.util.*
 
 class HistorySearchAdapter(
@@ -28,16 +26,6 @@ class HistorySearchAdapter(
                 this.historyListener = historyListener
                 this.historyId = historyItem.id
                 this.tvTime.text = convertTimeToTimeAgo(historyItem.datetime)
-
-                if (historyItem.faviconBitmap() == null) {
-                    val bm =
-                        AppCompatResources.getDrawable(
-                            ContextUtils.getApplicationContext(),
-                            R.drawable.ic_browser
-                        )
-
-                    this.favicon.setImageDrawable(bm)
-                }
 
                 executePendingBindings()
             }

--- a/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/TopPageAdapter.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/TopPageAdapter.kt
@@ -9,6 +9,7 @@ import android.widget.ArrayAdapter
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.myAllVideoBrowser.R
 import com.myAllVideoBrowser.data.local.room.entity.PageInfo
@@ -29,15 +30,14 @@ class TopPageAdapter(
         }
 
         with(binding) {
-            this?.pageInfo = pageInfos[position]
+            val page = pageInfos[position]
+            this?.pageInfo = page
             this?.listener = itemListener
-            if (this?.pageInfo?.faviconBitmap() != null) {
-                this.imgIcon.setImageBitmap(pageInfo!!.faviconBitmap())
-            } else {
-                val drawable = AppCompatResources.getDrawable(
-                    ContextUtils.getApplicationContext(), R.drawable.ic_browser
-                )
-                drawable?.setColorFilter(
+            
+            val placeholder = AppCompatResources.getDrawable(
+                context, R.drawable.ic_browser
+            )?.apply {
+                setColorFilter(
                     MaterialColors.getColor(
                         context,
                         com.google.android.material.R.attr.colorOnSurfaceVariant,
@@ -45,8 +45,17 @@ class TopPageAdapter(
                     ),
                     PorterDuff.Mode.SRC_IN
                 )
-                this?.imgIcon?.setImageDrawable(drawable)
             }
+
+            this?.imgIcon?.let { imageView ->
+                Glide.with(imageView.context)
+                    .load(page.favicon)
+                    .placeholder(placeholder)
+                    .error(placeholder)
+                    .circleCrop()
+                    .into(imageView)
+            }
+
             this?.executePendingBindings()
         }
 

--- a/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/WebTabsAdapter.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/component/adapter/WebTabsAdapter.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.google.android.material.color.MaterialColors
 import com.myAllVideoBrowser.R
 import com.myAllVideoBrowser.databinding.ItemWebTabButtonBinding
@@ -97,18 +98,17 @@ class WebTabsAdapter(
 
                     this.faviconTab.setImageDrawable(bm)
                 } else {
-                    val favicon = webTab.getFavicon()
-                    if (favicon != null) {
-                        this.faviconTab.setImageBitmap(favicon)
-                    } else {
-                        val bm =
-                            AppCompatResources.getDrawable(
-                                context,
-                                R.drawable.public_24px
-                            )
+                    val placeholder = AppCompatResources.getDrawable(
+                        context,
+                        R.drawable.public_24px
+                    )
 
-                        this.faviconTab.setImageDrawable(bm)
-                    }
+                    Glide.with(context)
+                        .load(webTab.getFavicon())
+                        .placeholder(placeholder)
+                        .error(placeholder)
+                        .circleCrop()
+                        .into(this.faviconTab)
                 }
 
                 if (!webTab.isHome()) {

--- a/app/src/main/java/com/myAllVideoBrowser/ui/component/binding/ImageBinding.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/component/binding/ImageBinding.kt
@@ -6,13 +6,25 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.widget.ImageView
 import com.bumptech.glide.Glide
+import com.myAllVideoBrowser.R
 
 object ImageBinding {
 
     @BindingAdapter("app:imageUrl")
     @JvmStatic
-    fun ImageView.loadImage(url: String) {
+    fun ImageView.loadImage(url: String?) {
         Glide.with(context).load(url).into(this)
+    }
+
+    @BindingAdapter("app:favicon")
+    @JvmStatic
+    fun ImageView.loadFavicon(bytes: ByteArray?) {
+        Glide.with(context)
+            .load(bytes)
+            .placeholder(R.drawable.ic_browser)
+            .error(R.drawable.ic_browser)
+            .circleCrop()
+            .into(this)
     }
 
     @BindingAdapter("app:bitmap")

--- a/app/src/main/java/com/myAllVideoBrowser/ui/main/history/HistoryFragment.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/main/history/HistoryFragment.kt
@@ -107,7 +107,7 @@ class HistoryFragment : BaseFragment() {
                 it?.let { item ->
                     parentFragmentManager.popBackStack()
                     BrowserViewModel.instance?.openPageEvent?.value =
-                        WebTab(item.url, item.title, item.faviconBitmap())
+                        WebTab(item.url, item.title, item.favicon)
                 }
             }
         }
@@ -136,7 +136,7 @@ class HistoryFragment : BaseFragment() {
                     }
                     parentFragmentManager.popBackStack()
                     BrowserViewModel.instance?.openPageEvent?.value =
-                        WebTab(item.url, item.title, item.faviconBitmap())
+                        WebTab(item.url, item.title, item.favicon)
                 }
             }
         }

--- a/app/src/main/java/com/myAllVideoBrowser/ui/main/home/browser/CustomWebChromeClient.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/main/home/browser/CustomWebChromeClient.kt
@@ -60,7 +60,7 @@ class CustomWebChromeClient(
                 resultMsg = resultMsg,
                 url = url,
                 title = "Loading...",
-                iconBytes = null
+                icon = null
             )
 
         return true

--- a/app/src/main/java/com/myAllVideoBrowser/ui/main/home/browser/CustomWebViewClient.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/main/home/browser/CustomWebViewClient.kt
@@ -99,14 +99,14 @@ class CustomWebViewClient(
 
         if (url != null && lastSavedHistoryUrl != url) {
             historyModel.viewModelScope.launch(historyModel.executorSingleHistory) {
-                val icon = try {
+                val iconBytes = try {
                     FaviconUtils.getEncodedFaviconFromUrl(
                         okHttpProxyClient.getProxyOkHttpClient(), url
                     )
                 } catch (_: Throwable) {
                     null
                 }
-                saveUrlToHistory(url, icon, viewTitle ?: title)
+                saveUrlToHistory(url, iconBytes, viewTitle ?: title)
 
                 videoDetectionModel.onStartPage(
                     url,
@@ -328,7 +328,7 @@ class CustomWebViewClient(
         return super.onRenderProcessGone(view, detail)
     }
 
-    private suspend fun saveUrlToHistory(url: String, favicon: Bitmap?, title: String?) {
+    private suspend fun saveUrlToHistory(url: String, favicon: Any?, title: String?) {
         val isTitleEmpty = title?.trim()?.isEmpty() == true
 
         if (!isTitleEmpty && lastSavedTitleHistory != title && lastSavedHistoryUrl != url && url.isNotEmpty() && !url.contains(
@@ -338,7 +338,11 @@ class CustomWebViewClient(
             lastSavedHistoryUrl = url
             lastSavedTitleHistory = title ?: ""
 
-            val outputFavicon = FaviconUtils.bitmapToBytes(favicon)
+            val outputFavicon = when (favicon) {
+                is Bitmap -> FaviconUtils.bitmapToBytes(favicon)
+                is ByteArray -> favicon
+                else -> null
+            }
 
             yield()
 

--- a/app/src/main/java/com/myAllVideoBrowser/ui/main/home/browser/webTab/WebTab.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/ui/main/home/browser/webTab/WebTab.kt
@@ -1,7 +1,6 @@
 package com.myAllVideoBrowser.ui.main.home.browser.webTab
 
 import android.annotation.SuppressLint
-import android.graphics.Bitmap
 import android.os.Message
 import android.webkit.WebView
 import java.util.UUID
@@ -9,7 +8,7 @@ import java.util.UUID
 class WebTab(
     private val url: String,
     private val title: String?,
-    private val iconBytes: Bitmap? = null,
+    private val icon: Any? = null,
     private val headers: Map<String, String> = emptyMap(),
     private var webview: WebView? = null,
     private var resultMsg: Message? = null,
@@ -53,8 +52,8 @@ class WebTab(
         return this.title ?: ""
     }
 
-    fun getFavicon(): Bitmap? {
-        return iconBytes
+    fun getFavicon(): Any? {
+        return icon
     }
 
     fun isHome(): Boolean {
@@ -63,7 +62,7 @@ class WebTab(
 
 
     override fun toString(): String {
-        return "WebTab(url='$url', title=$title, iconBytes=$iconBytes, headers=$headers, webview=$webview, resultMsg=$resultMsg, id='$id')"
+        return "WebTab(url='$url', title=$title, icon=$icon, headers=$headers, webview=$webview, resultMsg=$resultMsg, id='$id')"
     }
 
     override fun equals(other: Any?): Boolean {
@@ -74,7 +73,7 @@ class WebTab(
 
         if (url != other.url) return false
         if (title != other.title) return false
-        if (iconBytes != other.iconBytes) return false
+        if (icon != other.icon) return false
         if (headers != other.headers) return false
         if (webview != other.webview) return false
         if (resultMsg != other.resultMsg) return false
@@ -86,7 +85,7 @@ class WebTab(
     override fun hashCode(): Int {
         var result = url.hashCode()
         result = 31 * result + (title?.hashCode() ?: 0)
-        result = 31 * result + (iconBytes?.hashCode() ?: 0)
+        result = 31 * result + (icon?.hashCode() ?: 0)
         result = 31 * result + headers.hashCode()
         result = 31 * result + (webview?.hashCode() ?: 0)
         result = 31 * result + (resultMsg?.hashCode() ?: 0)

--- a/app/src/main/java/com/myAllVideoBrowser/util/FaviconUtils.kt
+++ b/app/src/main/java/com/myAllVideoBrowser/util/FaviconUtils.kt
@@ -1,7 +1,6 @@
 package com.myAllVideoBrowser.util
 
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import kotlinx.coroutines.delay
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -13,19 +12,19 @@ import java.io.ByteArrayOutputStream
 
 class FaviconUtils {
     companion object {
-        fun bitmapToBytes(bitmap: Bitmap?): ByteArray {
+        fun bitmapToBytes(bitmap: Bitmap?): ByteArray? {
+            if (bitmap == null) return null
             val stream = ByteArrayOutputStream()
-            bitmap?.compress(Bitmap.CompressFormat.PNG, 90, stream)
-
+            bitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
             return stream.toByteArray()
         }
 
-        suspend fun getEncodedFaviconFromUrl(okHttpClient: OkHttpClient, url: String): Bitmap? {
+        suspend fun getEncodedFaviconFromUrl(okHttpClient: OkHttpClient, url: String): ByteArray? {
             delay(0)
-            return fetchFavicon(okHttpClient, url)
+            return fetchFaviconBytes(okHttpClient, url)
         }
 
-        private fun fetchFavicon(okHttpClient: OkHttpClient, url: String): Bitmap? {
+        private fun fetchFaviconBytes(okHttpClient: OkHttpClient, url: String): ByteArray? {
             val potentialUrls = listOf(
                 "https://${Uri.parse(url).host}/favicon.ico",
                 "https://${
@@ -40,14 +39,19 @@ class FaviconUtils {
                 val safeUrl = reqUrl.toHttpUrlOrNull() ?: continue
 
                 val request = Request.Builder().url(safeUrl).build()
-                val response = okHttpClient.newCall(request).execute()
+                try {
+                    val response = okHttpClient.newCall(request).execute()
 
-                if (response.isSuccessful) {
-                    response.body.byteStream().use { stream ->
-                        return BitmapFactory.decodeStream(stream)
+                    if (response.isSuccessful) {
+                        val bytes = response.body.bytes()
+                        if (bytes.isNotEmpty()) {
+                            return bytes
+                        }
                     }
+                    response.close()
+                } catch (e: Exception) {
+                    // Ignore and try next URL
                 }
-                response.close()
             }
 
             return null

--- a/app/src/main/res/layout/item_bookmark.xml
+++ b/app/src/main/res/layout/item_bookmark.xml
@@ -43,7 +43,7 @@
                 android:layout_width="40dp"
                 android:layout_height="40dp"
                 android:importantForAccessibility="no"
-                app:bitmap="@{bookmarkItem.faviconBitmap()}"
+                app:favicon="@{bookmarkItem.favicon}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/item_history.xml
+++ b/app/src/main/res/layout/item_history.xml
@@ -44,7 +44,7 @@
                 android:layout_height="40dp"
                 android:layout_marginStart="4dp"
                 android:importantForAccessibility="no"
-                app:bitmap="@{historyItem.faviconBitmap()}"
+                app:favicon="@{historyItem.favicon}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/item_history_search.xml
+++ b/app/src/main/res/layout/item_history_search.xml
@@ -44,7 +44,7 @@
                 android:layout_height="40dp"
                 android:layout_marginStart="4dp"
                 android:importantForAccessibility="no"
-                app:bitmap="@{historyItem.faviconBitmap()}"
+                app:favicon="@{historyItem.favicon}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
…tubeDL initialization safety

- Refactor `FaviconUtils` to return `ByteArray` instead of `Bitmap` and add error handling during fetch.
- Update `HistoryItem` and `PageInfo` entities to remove `faviconBitmap()` helper in favor of direct `ByteArray` usage.
- Migrate `BookmarksAdapter`, `HistoryAdapter`, `TopPageAdapter`, and `WebTabsAdapter` to use Glide for favicon loading with circular cropping and placeholders.
- Add `app:favicon` BindingAdapter in `ImageBinding` to handle `ByteArray` inputs via Glide.
- Update `WebTab` to hold generic `icon` property instead of `Bitmap`.
- Improve `DLApplication` initialization by adding an `isYoutubeDLInitialized` flag and enhanced error logging for YoutubeDL and FFmpeg setup.
- Update layout files to use the new `app:favicon` binding attribute.